### PR TITLE
ci(build): remove yarn build from build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Lint
         run: yarn run lint
 
-      - name: Build
-        run: yarn run build
-
       - name: Test
         run: yarn run coverage
 


### PR DESCRIPTION
# Description

#### Please describe the reason related to the changes:

Remove step 'yarn build' since it is already called with 'yarn install'.

# Type

#### Please select the type related to the changes:

- [ ] bugfix
- [ ] build
- [x] continuous delivery (CD)
- [ ] continuous integration (CI)
- [ ] documentation
- [ ] feature
- [ ] formatting
- [ ] refactoring
- [ ] styling
- [ ] other (please describe below):

# Breaking Change

#### Does your changes introduce a breaking change?

- [x] no
- [ ] yes

# Behavior

#### Please describe the current behavior:

# Changes

#### Please describe the new behavior:

# Information (issue, links, logs, etc.)

#### Please list any other useful information:

# Checklist

#### Please make sure this pull request follow the requirements

- [x] commit guidelines [@commitlint/config-conventional](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] **100%** code coverage
- [x] tests passing
